### PR TITLE
Added config to CCXT feed parameters

### DIFF
--- a/backtrader/brokers/ccxtbroker.py
+++ b/backtrader/brokers/ccxtbroker.py
@@ -63,12 +63,16 @@ class CCXTBroker(BrokerBase):
         self.currency = currency
 
         self.notifs = queue.Queue()  # holds orders which are notified
+        self.startingcash = self.cash = 0.0
+        self.startingvalue = self.value = 0.0
 
     def getcash(self):
-        return self.exchange.fetch_balance()['free'][self.currency]
+        self.cash = self.exchange.fetch_balance()['free'][self.currency]
+        return self.cash
 
     def getvalue(self):
-        return self.exchange.fetch_balance()['total'][self.currency]
+        self.value = self.exchange.fetch_balance()['total'][self.currency]
+        return self.value
 
     def get_notification(self):
         try:

--- a/backtrader/feeds/ccxt.py
+++ b/backtrader/feeds/ccxt.py
@@ -83,8 +83,8 @@ class CCXT(DataBase):
     # States for the Finite State Machine in _load
     _ST_LIVE, _ST_HISTORBACK, _ST_OVER = range(3)
 
-    def __init__(self, exchange, symbol, ohlcv_limit=450):
-        self.exchange = getattr(ccxt, exchange)()
+    def __init__(self, exchange, symbol, config, ohlcv_limit=450):
+        self.exchange = getattr(ccxt, exchange)(config)
         self.symbol = symbol
         self.ohlcv_limit = ohlcv_limit
 

--- a/backtrader/feeds/ccxt.py
+++ b/backtrader/feeds/ccxt.py
@@ -83,7 +83,7 @@ class CCXT(DataBase):
     # States for the Finite State Machine in _load
     _ST_LIVE, _ST_HISTORBACK, _ST_OVER = range(3)
 
-    def __init__(self, exchange, symbol, config, ohlcv_limit=450):
+    def __init__(self, exchange, symbol, ohlcv_limit=450, config={}):
         self.exchange = getattr(ccxt, exchange)(config)
         self.symbol = symbol
         self.ohlcv_limit = ohlcv_limit


### PR DESCRIPTION
It's worth adding the config parameter to the feed class as well. Otherwise when trying to use sandbox broker is instantiated with a proper endpoint and feed still uses real environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bartosh/backtrader/3)
<!-- Reviewable:end -->
