### PR TITLE
Make sure feeds.CCXT._fetch_ohlcv handles empty list of candles

### DIFF
--- a/backtrader/feeds/ccxt.py
+++ b/backtrader/feeds/ccxt.py
@@ -121,8 +121,12 @@ class CCXT(DataBase):
 
         while True:
             dlen = len(self._data)
-            for ohlcv in sorted(self.store.fetch_ohlcv(self.symbol, timeframe=granularity,
-                                                       since=since, limit=limit)):
+            candles = sorted(self.store.fetch_ohlcv(self.symbol, timeframe=granularity,
+                                                       since=since, limit=limit))
+            if len(candles) == 0 and since is not None and self._last_ts == 0:
+                # No candles = no trades, make sure _last_ts is correct
+                self._last_ts = since
+            for ohlcv in candles:
                 if None in ohlcv:
                     continue
 


### PR DESCRIPTION
On low-volume assets and short timeframes there can be periods without any trades. Some exchanges will return an empty list of candles for these periods. In feeds.ccxt.CCXT this results in self._last_ts remaining at its initial value of 0, ignoring the initial value of fromdate. On the next run, _fetch_ohlcv will thus start with since = None, trying retrieve years of data.

Not sure if this is the correct way to handle the situation, but at least it works around the initial problem of retrieving the entire history from the exchange. A cleaner solution might be to get the value for both since and _last_ts before the "for ohlcv in.." loop.